### PR TITLE
Added a custom skiplink behavior for hash routing.

### DIFF
--- a/src/components/SkipLink/SkipLink.jsx
+++ b/src/components/SkipLink/SkipLink.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
+import { MAIN_ID } from "../../constants";
 import "./skiplink.css";
 
 const SkipLink = props => {
@@ -13,10 +14,20 @@ const SkipLink = props => {
     }
   }, [location, skipLinkVisible]);
 
+  const handleClick = e => {
+    e.preventDefault();
+
+    const target = document.getElementById(MAIN_ID);
+    target.scrollIntoView();
+    target.setAttribute('tabindex', '-1');
+    target.focus({ preventScroll:true });
+  }
+
   return (
     <a
       className="continuum-skip-link"
       href="#main"
+      onClick={handleClick}
       ref={skipLinkRef}
     >
       Skip to content

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,3 @@
+const MAIN_ID = 'main';
+
+export { MAIN_ID };

--- a/src/routes/Expenses.jsx
+++ b/src/routes/Expenses.jsx
@@ -1,6 +1,7 @@
 import DocumentHead from "../components/DocumentHead/DocumentHead";
 import PageLiveRegion from "../components/PageLiveRegion/PageLiveRegion";
 import Header from "../components/Header/Header";
+import { MAIN_ID } from "../constants";
 
 const Expenses = props => {
   const {
@@ -15,7 +16,7 @@ const Expenses = props => {
       <PageLiveRegion pageTitle={pageTitle} />
       <Header handleSkipLink={handleSkipLink} skipLinkVisible={skipLinkVisible} />
 
-      <main className="continuum-global-main" id="main">
+      <main className="continuum-global-main" id={MAIN_ID}>
         <h1>Expenses</h1>
         <a href="https://github.com/1Copenut/SPA-routing-experience">GitHub link to verify focus</a>
         <p>Expense listings and definitions for our products</p>

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -1,6 +1,7 @@
 import DocumentHead from "../components/DocumentHead/DocumentHead";
 import PageLiveRegion from "../components/PageLiveRegion/PageLiveRegion";
 import Header from "../components/Header/Header";
+import { MAIN_ID } from "../constants";
 
 const Home = props => {
   const {
@@ -15,7 +16,7 @@ const Home = props => {
       <PageLiveRegion pageTitle={pageTitle} />
       <Header handleSkipLink={handleSkipLink} skipLinkVisible={skipLinkVisible} />
 
-      <main className="continuum-global-main" id="main">
+      <main className="continuum-global-main" id={MAIN_ID}>
         <h1>Home</h1>
         <a href="https://github.com/1Copenut/SPA-routing-experience">GitHub link to verify focus</a>
         <p>Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall value proposition. Organically grow the holistic world view of disruptive innovation via workplace diversity and empowerment.</p>

--- a/src/routes/Invoices.jsx
+++ b/src/routes/Invoices.jsx
@@ -1,6 +1,7 @@
 import DocumentHead from "../components/DocumentHead/DocumentHead";
 import PageLiveRegion from "../components/PageLiveRegion/PageLiveRegion";
 import Header from "../components/Header/Header";
+import { MAIN_ID } from "../constants";
 
 const Invoices = props => {
   const {
@@ -15,7 +16,7 @@ const Invoices = props => {
       <PageLiveRegion pageTitle={pageTitle} />
       <Header handleSkipLink={handleSkipLink} skipLinkVisible={skipLinkVisible} />
 
-      <main className="continuum-global-main" id="main">
+      <main className="continuum-global-main" id={MAIN_ID}>
         <h1>Invoices</h1>
         <a href="https://github.com/1Copenut/SPA-routing-experience">GitHub link to verify focus</a>
         <p>We are invoicing for Q3 FY2022 this month. Outstanding invoices and details are below.</p>


### PR DESCRIPTION
The skip link behavior was borked when I had to switch to hash routing for GH pages. This fixes #5 cross-browser (evergreen browsers Chrome, Firefox, Safari, Edge tested on MacOS).