### PR TITLE
Refactoring live region ahead of skip link.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,47 +1,52 @@
 import { useState } from "react";
-import {
-  HashRouter,
-  Routes,
-  Route
-} from "react-router-dom";
-import Home from './routes/Home';
-import Expenses from './routes/Expenses';
-import Invoices from './routes/Invoices';
+import { HashRouter, Routes, Route } from "react-router-dom";
+import Home from "./routes/Home";
+import Expenses from "./routes/Expenses";
+import Invoices from "./routes/Invoices";
 import Template from "./routes/Template";
 
 const App = () => {
-  const [ skipLinkVisible, setSkipLinkVisible ] = useState(false);
+  const [currentPageTitle, setCurrentPageTitle] = useState("");
 
-  const handleSkipLink = () => {
-    setSkipLinkVisible(!skipLinkVisible);
-  }
+  const handlePageTitle = (title) => {
+    setCurrentPageTitle(title);
+  };
 
   return (
     <HashRouter>
       <Routes>
-        <Route path="/" element={<Template skipLinkVisible={skipLinkVisible} />}>
-          <Route index element={
-            <Home
-              pageTitle="We Say So Homepage"
-              handleSkipLink={handleSkipLink}
-              skipLinkVisible={skipLinkVisible}
-            />} />
-          <Route path="expenses" element={
-            <Expenses
-              pageTitle="We Say So Expenses"
-              handleSkipLink={handleSkipLink}
-              skipLinkVisible={skipLinkVisible}
-            />} />
-          <Route path="invoices" element={
-            <Invoices
-              pageTitle="We Say So Invoices"
-              handleSkipLink={handleSkipLink}
-              skipLinkVisible={skipLinkVisible}
-            />} />
+        <Route path="/" element={<Template pageTitle={currentPageTitle} />}>
+          <Route
+            index
+            element={
+              <Home
+                pageTitle="We Say So Homepage"
+                handlePageTitle={handlePageTitle}
+              />
+            }
+          />
+          <Route
+            path="expenses"
+            element={
+              <Expenses
+                pageTitle="We Say So Expenses"
+                handlePageTitle={handlePageTitle}
+              />
+            }
+          />
+          <Route
+            path="invoices"
+            element={
+              <Invoices
+                pageTitle="We Say So Invoices"
+                handlePageTitle={handlePageTitle}
+              />
+            }
+          />
         </Route>
       </Routes>
     </HashRouter>
   );
-}
+};
 
 export default App;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,36 +1,13 @@
 import { Link } from "react-router-dom";
 import "./header.css";
 
-const Header = props => {
-  const { handleSkipLink, skipLinkVisible } = props;
-
-  const handleClick = e => {
-    // offsetX and offsetY were the only reliable measurements
-    // across evergreen browsers to derive mouse click from 
-    // Enter keypress
-    const { offsetX, offsetY } = e.nativeEvent;
-    
-    if ((offsetX !== 0) || (offsetY !== 0)) {
-      if (skipLinkVisible) {
-        handleSkipLink(false);
-        console.log('Flipped show skip link to false');
-      }
-    }
-
-    if ((offsetX === 0) && (offsetY === 0)) {
-      if (!skipLinkVisible) {
-        handleSkipLink(true);
-        console.log('Flipped show skip link to true');
-      }
-    }
-  }
-
+const Header = () => {
   return (
     <header className="continuum-global-header">
       <nav className="continuum-global-nav">
-        <Link to="/" onClick={handleClick}>Home</Link>
-        <Link to="/invoices" onClick={handleClick}>Invoices</Link>
-        <Link to="/expenses" onClick={handleClick}>Expenses</Link>
+        <Link to="/">Home</Link>
+        <Link to="/invoices">Invoices</Link>
+        <Link to="/expenses">Expenses</Link>
       </nav>
     </header>
   );

--- a/src/components/PageLiveRegion/PageLiveRegion.jsx
+++ b/src/components/PageLiveRegion/PageLiveRegion.jsx
@@ -1,11 +1,16 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const PageLiveRegion = props => {
   const { pageTitle } = props;
   const [ titleState, setTitleState ] = useState('');
+  const liveRef = useRef(null);
 
   useEffect(() => {
     setTitleState(pageTitle);
+
+    if (liveRef) {
+      liveRef.current.focus();
+    }
 
     return () => {
       setTitleState('');
@@ -18,7 +23,9 @@ const PageLiveRegion = props => {
       aria-live="polite"
       aria-relevant="text additions"
       className="continuum-sr-only"
+      ref={liveRef}
       role="status"
+      tabIndex="-1"
     >
       {`Viewing ${titleState}`}
     </div>

--- a/src/components/SkipLink/SkipLink.jsx
+++ b/src/components/SkipLink/SkipLink.jsx
@@ -1,19 +1,8 @@
-import { useEffect, useRef } from "react";
-import { useLocation } from "react-router-dom";
+// import { useLocation } from "react-router-dom";
 import { MAIN_ID } from "../../constants";
 import "./skiplink.css";
 
-const SkipLink = props => {
-  const { skipLinkVisible } = props;
-  const location = useLocation();
-  const skipLinkRef = useRef(null);
-
-  useEffect(() => {
-    if (skipLinkVisible && skipLinkRef) {
-      skipLinkRef.current.focus();
-    }
-  }, [location, skipLinkVisible]);
-
+const SkipLink = () => {
   const handleClick = e => {
     e.preventDefault();
 
@@ -28,7 +17,6 @@ const SkipLink = props => {
       className="continuum-skip-link"
       href="#main"
       onClick={handleClick}
-      ref={skipLinkRef}
     >
       Skip to content
     </a>

--- a/src/routes/Expenses.jsx
+++ b/src/routes/Expenses.jsx
@@ -1,20 +1,20 @@
-import DocumentHead from "../components/DocumentHead/DocumentHead";
-import PageLiveRegion from "../components/PageLiveRegion/PageLiveRegion";
 import Header from "../components/Header/Header";
 import { MAIN_ID } from "../constants";
+import { useEffect } from "react";
 
 const Expenses = props => {
   const {
-    handleSkipLink,
+    handlePageTitle,
     pageTitle,
-    skipLinkVisible
   } = props;
+
+  useEffect(() => {
+    handlePageTitle(pageTitle);
+  }, [handlePageTitle, pageTitle]);
 
   return (
     <>
-      <DocumentHead pageTitle={pageTitle} />
-      <PageLiveRegion pageTitle={pageTitle} />
-      <Header handleSkipLink={handleSkipLink} skipLinkVisible={skipLinkVisible} />
+      <Header />
 
       <main className="continuum-global-main" id={MAIN_ID}>
         <h1>Expenses</h1>

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -1,20 +1,20 @@
-import DocumentHead from "../components/DocumentHead/DocumentHead";
-import PageLiveRegion from "../components/PageLiveRegion/PageLiveRegion";
 import Header from "../components/Header/Header";
 import { MAIN_ID } from "../constants";
+import { useEffect } from "react";
 
 const Home = props => {
   const {
-    handleSkipLink,
+    handlePageTitle,
     pageTitle,
-    skipLinkVisible
   } = props;
+
+  useEffect(() => {
+    handlePageTitle(pageTitle);
+  }, [handlePageTitle, pageTitle]);
 
   return (
     <>
-      <DocumentHead pageTitle={pageTitle} />
-      <PageLiveRegion pageTitle={pageTitle} />
-      <Header handleSkipLink={handleSkipLink} skipLinkVisible={skipLinkVisible} />
+      <Header />
 
       <main className="continuum-global-main" id={MAIN_ID}>
         <h1>Home</h1>

--- a/src/routes/Invoices.jsx
+++ b/src/routes/Invoices.jsx
@@ -1,20 +1,20 @@
-import DocumentHead from "../components/DocumentHead/DocumentHead";
-import PageLiveRegion from "../components/PageLiveRegion/PageLiveRegion";
 import Header from "../components/Header/Header";
 import { MAIN_ID } from "../constants";
+import { useEffect } from "react";
 
 const Invoices = props => {
   const {
-    handleSkipLink,
+    handlePageTitle,
     pageTitle,
-    skipLinkVisible
   } = props;
+
+  useEffect(() => {
+    handlePageTitle(pageTitle);
+  }, [handlePageTitle, pageTitle]);
 
   return (
     <>
-      <DocumentHead pageTitle={pageTitle} />
-      <PageLiveRegion pageTitle={pageTitle} />
-      <Header handleSkipLink={handleSkipLink} skipLinkVisible={skipLinkVisible} />
+      <Header />
 
       <main className="continuum-global-main" id={MAIN_ID}>
         <h1>Invoices</h1>

--- a/src/routes/Template.jsx
+++ b/src/routes/Template.jsx
@@ -1,12 +1,16 @@
 import { Outlet } from "react-router-dom";
+import DocumentHead from "../components/DocumentHead/DocumentHead";
+import PageLiveRegion from "../components/PageLiveRegion/PageLiveRegion";
 import SkipLink from "../components/SkipLink/SkipLink";
 
 const Template = props => {
-  const { skipLinkVisible } = props;
+  const { pageTitle } = props;
 
   return (
     <>
-      <SkipLink skipLinkVisible={skipLinkVisible} />
+      <DocumentHead pageTitle={pageTitle} />
+      <PageLiveRegion pageTitle={pageTitle} />
+      <SkipLink />
       <Outlet />
     </>
   );


### PR DESCRIPTION
I didn't like the previous iteration where the skip link would appear or not based on keyboard or mouse interaction. Moving to a simpler model where the live region is always first, then pressing `Tab` once will always focus the skip link.